### PR TITLE
Increase build number to fix protobuf issues

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     sha256: 85319cf801690f87059188d3185fce3713608e338e3595f0be6b74a25713c8ed
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Needs rebuild - https://github.com/conda-forge/gazebo-feedstock/pull/19 fails because of a changes in the protobuf API, see https://github.com/protocolbuffers/protobuf/issues/7522 and https://github.com/protocolbuffers/protobuf/issues/7496 and https://github.com/osrf/homebrew-simulation/issues/1042