### PR TITLE
Bump version to 6.2.0 and cleanup

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   - url: https://github.com/ignitionrobotics/ign-msgs/archive/ignition-msgs{{ version.split('.')[0] }}_{{ version }}.tar.gz
-    sha256: 231b0b302a854fb0f838174ea2b86cac96ed137d2d6d51174ba024f6b30b9baf
+    sha256: c0e8fa4fd92cb871504b37d6779092560fba7745a2e9257394ffcc3dda96c4de
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set base_name = "libignition-msgs" %}
-{% set version = "6.1.0" %}
+{% set version = "6.2.0" %}
 {% set name = base_name + version.split('.')[0] %}
 
 package:
@@ -11,17 +11,14 @@ source:
     sha256: 231b0b302a854fb0f838174ea2b86cac96ed137d2d6d51174ba024f6b30b9baf
 
 build:
-  number: 1
-  skip: true  # [win and vc<14]
+  number: 0
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 
 requirements:
   build:
-    - {{ compiler('cxx') }}              # [not win]
-    - {{ compiler('c') }}                # [not win]
-    - vs2017_win-64                      # [win64]
-    - vs2017_win-32                      # [win32]
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
     - make                               # [not win]
     - cmake
     - pkg-config                         # [not win]
@@ -50,7 +47,7 @@ test:
     - if exist %PREFIX%\\Library\\lib\\cmake\\ignition-msgs{{ version.split('.')[0] }}\\ignition-msgs{{ version.split('.')[0] }}-config.cmake (exit 0) else (exit 1)  # [win]
 
 about:
-  home: https://bitbucket.org/ignitionrobotics/ign-msgs
+  home: https://github.com/ignitionrobotics/ign-msgs
   license: Apache-2.0
   license_file: LICENSE
   summary: Ignition Messages


### PR DESCRIPTION
Necessary to unblock https://github.com/conda-forge/libignition-transport4-feedstock/pull/21 . I also took the occasion for a small cleanup. 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
