### PR TITLE
Bump build number in v5 branch and cleanup

### DIFF
--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 libprotobuf:
-- '3.13'
+- '3.14'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 libprotobuf:
-- '3.13'
+- '3.14'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/migrations/libprotobuf314.yaml
+++ b/.ci_support/migrations/libprotobuf314.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libprotobuf:
-- '3.14'
-migrator_ts: 1607035151.2279923

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,8 +1,10 @@
+c_compiler:
+- vs2017
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- vs2017
 target_platform:
 - win-64
-vc:
-- '14'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About libignition-msgs5
 =======================
 
-Home: https://bitbucket.org/ignitionrobotics/ign-msgs
+Home: https://github.com/ignitionrobotics/ign-msgs
 
 Package license: Apache-2.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,20 +11,17 @@ source:
     sha256: 1e11986cdf9549f1b4e2a6da1b978525ff2f60539a451b24db5b81ca2c0893df
 
 build:
-  number: 3
-  skip: true  # [win and vc<14]
+  number: 4
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 
 requirements:
   build:
-    - {{ compiler('cxx') }}              # [not win]
-    - {{ compiler('c') }}                # [not win]
-    - vs2017_win-64                      # [win64]
-    - vs2017_win-32                      # [win32]
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
     - make                               # [not win]
     - cmake
-    - pkg-config                         # [not win]
+    - pkg-config
   host:
     - libignition-math6 >=6.6
     - tinyxml2
@@ -48,7 +45,7 @@ test:
     - if exist %PREFIX%\\Library\\lib\\cmake\\ignition-msgs{{ version.split('.')[0] }}\\ignition-msgs{{ version.split('.')[0] }}-config.cmake (exit 0) else (exit 1)  # [win]
 
 about:
-  home: https://bitbucket.org/ignitionrobotics/ign-msgs
+  home: https://github.com/ignitionrobotics/ign-msgs
   license: Apache-2.0
   license_file: LICENSE
   summary: Ignition Messages


### PR DESCRIPTION
I am not 100% sure, but I think that something went wrong in the libprotobuf314/arch migration for the v5.3.0 branch, and this is causing the issues in https://github.com/conda-forge/libignition-transport4-feedstock/pull/26 . I took the occasion for the usual cleanup. 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

