### PR TITLE
Fix to correctly depend on libprotobuf on Windows

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -6,5 +6,7 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2017
+libprotobuf:
+- '3.15'
 target_platform:
 - win-64

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     sha256: c0e8fa4fd92cb871504b37d6779092560fba7745a2e9257394ffcc3dda96c4de
 
 build:
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 
@@ -21,19 +21,19 @@ requirements:
     - {{ compiler('c') }}
     - make                               # [not win]
     - cmake
-    - pkg-config                         # [not win]
+    - pkg-config
   host:
     - libignition-math6 >=6.4
     - libignition-tools1
     - tinyxml2
     - protobuf
-    - libprotobuf                        # [not win]
+    - libprotobuf
   run:
     - libignition-math6 >=6.4
     - libignition-tools1
     - tinyxml2
     - protobuf
-    - libprotobuf                        # [not win]
+
 
 test:
   commands:


### PR DESCRIPTION
Now that the protobuf 3.15 migration is ongoing, I am experiencing some build failures just on Windows in my downstream CI only on Windows: https://github.com/robotology/robotology-superbuild/actions/runs/587714804 . The error is due to the fact that a ignition-msgs5 that is build with libprotobuf3.15 is installed, even if gazebo build with  libprotobuf3.14 is also installed. 

It turns out that this happens as on Windows this package does not depend on libprotobuf, that is the package that with its run_exports exports the correct constraint on protobuf version. This PR cleanups a bit the declaration of dependency on libprotobuf, removing it from the run dependencies as this behaviour is already provided by run_exports. 

We may need also to fix the dependency information for already released packages to avoid this problem to emerge at each new protobuf migration, but let's do one thing at the time. 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

