### PR TITLE
Fix to correctly depend on libprotobuf on Windows  (v5 branch)

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -6,5 +6,7 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2017
+libprotobuf:
+- '3.15'
 target_platform:
 - win-64

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     sha256: 1e11986cdf9549f1b4e2a6da1b978525ff2f60539a451b24db5b81ca2c0893df
 
 build:
-  number: 5
+  number: 6
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 
@@ -26,12 +26,11 @@ requirements:
     - libignition-math6 >=6.6
     - tinyxml2
     - protobuf
-    - libprotobuf                        # [not win]
+    - libprotobuf
   run:
     - libignition-math6 >=6.6
     - tinyxml2
     - protobuf
-    - libprotobuf                        # [not win]
 
 test:
   commands:


### PR DESCRIPTION
Version of https://github.com/conda-forge/libignition-msgs1-feedstock/pull/28 for the v5 branch.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
