### PR TITLE
Fix conda-forge.yml to avoid duplicate bot entry and unblock tinyxml2-9 migration

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,7 @@
-bot: {automerge: true}
 conda_forge_output_validation: true
 provider: {linux_aarch64: default, linux_ppc64le: default}
 bot:
+  automerge: true
   abi_migration_branches:
     - "v5.3.0"
     - "v6.4.0"


### PR DESCRIPTION
No re-render should be necessary. Thanks @xhochy for the input.


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

