### PR TITLE
Fix duplicate bot key in conda-forge.yaml

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,6 @@
-bot: {automerge: true}
 conda_forge_output_validation: true
 provider: {linux_aarch64: default, linux_ppc64le: default}
 bot:
+  automerge: true
   abi_migration_branches:
     - "v5.3.0"


### PR DESCRIPTION
In the autotick-bot logs (see https://github.com/regro/autotick-bot/runs/3021590307?check_suite_focus=true), I still see the duplicate key error, related in someway to this branch:
~~~
2021-07-08T17:47:57.9411541Z 2021-07-08 17:47:57,940 INFO     conda_forge_tick.auto_tick || ARCHREBUILD-aarch64 and ppc64le addition IS MIGRATING libignition-msgs1:v6.4.0
2021-07-08T17:47:57.9414421Z INFO:github3:Building a url from ('https://api.github.com', 'rate_limit')
2021-07-08T17:47:57.9826438Z INFO:github3:JSON was returned
2021-07-08T17:47:57.9829655Z INFO:github3:Building a url from ('https://api.github.com', 'repos', 'conda-forge', 'libignition-msgs1-feedstock')
2021-07-08T17:47:57.9832017Z INFO:github3:Missed the cache building the url
2021-07-08T17:47:58.0763324Z INFO:github3:JSON was returned
2021-07-08T17:47:58.0786411Z INFO:github3:Building a url from ('https://api.github.com', 'repos', 'regro-cf-autotick-bot', 'libignition-msgs1-feedstock')
2021-07-08T17:47:58.0789090Z INFO:github3:Missed the cache building the url
2021-07-08T17:47:58.2103602Z INFO:github3:JSON was returned
2021-07-08T17:47:58.5102356Z ~/work/autotick-bot/autotick-bot/cf-graph/feedstocks/libignition-msgs1-feedstock ~/work/autotick-bot/autotick-bot/cf-graph
2021-07-08T17:47:59.5046610Z error: pathspec 'bot-pr_arch_h3dba18' did not match any file(s) known to git
2021-07-08T17:47:59.6003494Z ~/work/autotick-bot/autotick-bot/cf-graph
2021-07-08T17:47:59.6036707Z ~/work/autotick-bot/autotick-bot/cf-graph/feedstocks/libignition-msgs1-feedstock ~/work/autotick-bot/autotick-bot/cf-graph
2021-07-08T17:47:59.6101022Z ~/work/autotick-bot/autotick-bot/cf-graph
2021-07-08T17:47:59.6122727Z 2021-07-08 17:47:59,610 ERROR    conda_forge_tick.auto_tick || NON GITHUB ERROR
2021-07-08T17:47:59.6123757Z Traceback (most recent call last):
2021-07-08T17:47:59.6125153Z   File "/home/runner/work/autotick-bot/autotick-bot/cf-scripts/conda_forge_tick/auto_tick.py", line 1132, in main
2021-07-08T17:47:59.6126440Z     migrator_uid, pr_json = run(
2021-07-08T17:47:59.6127742Z   File "/home/runner/work/autotick-bot/autotick-bot/cf-scripts/conda_forge_tick/auto_tick.py", line 192, in run
2021-07-08T17:47:59.6129051Z     migrate_return = migrator.migrate(recipe_dir, feedstock_ctx.attrs, **kwargs)
2021-07-08T17:47:59.6130642Z   File "/home/runner/work/autotick-bot/autotick-bot/cf-scripts/conda_forge_tick/migrators/arch.py", line 117, in migrate
2021-07-08T17:47:59.6131672Z     y = safe_load(f)
2021-07-08T17:47:59.6132922Z   File "/usr/share/miniconda/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/main.py", line 1118, in safe_load
2021-07-08T17:47:59.6134050Z     return load(stream, SafeLoader, version)
2021-07-08T17:47:59.6135401Z   File "/usr/share/miniconda/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/main.py", line 1071, in load
2021-07-08T17:47:59.6136528Z     return loader._constructor.get_single_data()
2021-07-08T17:47:59.6138006Z   File "/usr/share/miniconda/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 122, in get_single_data
2021-07-08T17:47:59.6140572Z     return self.construct_document(node)
2021-07-08T17:47:59.6142165Z   File "/usr/share/miniconda/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 132, in construct_document
2021-07-08T17:47:59.6147067Z     for _dummy in generator:
2021-07-08T17:47:59.6148301Z   File "/usr/share/miniconda/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 722, in construct_yaml_map
2021-07-08T17:47:59.6149266Z     value = self.construct_mapping(node)
2021-07-08T17:47:59.6150507Z   File "/usr/share/miniconda/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 446, in construct_mapping
2021-07-08T17:47:59.6151703Z     return BaseConstructor.construct_mapping(self, node, deep=deep)
2021-07-08T17:47:59.6153330Z   File "/usr/share/miniconda/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 264, in construct_mapping
2021-07-08T17:47:59.6154404Z     if self.check_mapping_key(node, key_node, mapping, key, value):
2021-07-08T17:47:59.6156751Z   File "/usr/share/miniconda/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 295, in check_mapping_key
2021-07-08T17:47:59.6157737Z     raise DuplicateKeyError(*args)
2021-07-08T17:47:59.6158862Z ruamel.yaml.constructor.DuplicateKeyError: while constructing a mapping
2021-07-08T17:47:59.6160114Z   in "conda-forge.yml", line 1, column 1
2021-07-08T17:47:59.6160805Z found duplicate key "bot" with value "{}" (original value: "{}")
2021-07-08T17:47:59.6161626Z   in "conda-forge.yml", line 4, column 1
2021-07-08T17:47:59.6161997Z 
2021-07-08T17:47:59.6162420Z To suppress this check see:
2021-07-08T17:47:59.6163441Z     http://yaml.readthedocs.io/en/latest/api.html#duplicate-keys
2021-07-08T17:47:59.6164052Z 
2021-07-08T17:47:59.6164656Z Duplicate keys will become an error in future releases, and are errors
2021-07-08T17:47:59.6165367Z by default when using the new API.
2021-07-08T17:47:59.6165882Z 
2021-07-08T17:48:00.0089767Z 2021-07-08 17:48:00,008 INFO     conda_forge_tick.auto_tick || /home/runner/work/autotick-bot/autotick-bot/cf-graph
2021-07-08T17:48:00.0093998Z INFO:github3:Building a url from ('https://api.github.com', 'rate_limit')
2021-07-08T17:48:00.0586968Z INFO:github3:JSON was returned
2021-07-08T17:48:00.0594493Z 
2021-07-08T17:48:00.0595293Z 
2021-07-08T17:48:02.1036360Z 
~~~

I guess it is a good idea to also fix the yaml in this branch.