### PR TITLE
Pull in tinyxml2=9 for osx-arm64

### DIFF
--- a/.ci_support/migrations/tinyxml2-9.yaml
+++ b/.ci_support/migrations/tinyxml2-9.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-tinyxml2:
-- 9
-migrator_ts: 1624484606

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -19,7 +19,7 @@ macos_machine:
 target_platform:
 - osx-arm64
 tinyxml2:
-- '8'
+- '9'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     sha256: 6bb715b1ddff7d89e00794487631c64310164968dd2d8fe4094cfa8c8c4584cf
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
For some reason the osx-arm64 build is still using tinyxml2=8. This causes issues down the track: https://github.com/conda-forge/libignition-fuel-tools-feedstock/pull/40
Let's see whether a rerender will fix it.