### PR TITLE
Remove v6 from abi_migration_branches as it is not supported anymore

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,6 @@
 bot:
   abi_migration_branches:
   - v5.3.0
-  - v6.4.0
   - v7
   automerge: true
 build_platform:


### PR DESCRIPTION
See https://github.com/ignition-tooling/release-tools/issues/600 and https://github.com/ignitionrobotics/docs/blob/1ebf12f8f98e41b9174f158679051fb97b10070a/tools/versions.md .